### PR TITLE
Add hybridization hints

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ rustfmt:
   stage: prebuild
   cache: {}
   script:
-    - cargo format
+    - cargo fmt
 
 doc:
   stage: prebuild
@@ -27,7 +27,7 @@ clippy:
     # no feature activated
     - cargo clippy --all-targets -- -D warnings
     # all features activated
-    - cargo clippy-all
+    - cargo clippy --all-features --all-targets -- -D warnings
 
 # Security check
 cargo_audit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## [2.0.0] - 2023-01-04
+### Added
+- `AccessPolicy::to_attribute_combinations()`
+- `Policy::attribute_hybridization_hint()`
+### Changed
+- `PolicyAxis::new()` signature
+- `Policy::add_axis()` signature
+### Fixed
+### Removed
+- `Policy::attribute_current_value()`
+---
+
+---
 ## [1.0.1] - 2022-08-24
 ### Added
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,48 +13,48 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -85,18 +85,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -105,6 +105,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "abe_policy"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "abe_policy"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2021"
 authors = [
   "Bruno Grieder <bruno.grieder@cosmian.com>",
+  "Théophile Brézot <theophile.brezot@cosmian.com>",
 ]
 description = "Policy and attributes definition for ABE cryptosystems"
 documentation = "https://docs.rs/abe_policy/"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 //! Define this crate error type.
+
 use thiserror::Error;
 
 /// Crate error type.
@@ -28,4 +29,6 @@ pub enum Error {
     InvalidBooleanExpression(String),
     #[error("invalid attribute: {0}")]
     InvalidAttribute(String),
+    #[error("invalid axis: {0}")]
+    InvalidAxis(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod policy;
 pub use access_policy::AccessPolicy;
 pub use attribute::{Attribute, Attributes};
 pub use error::Error;
-pub use policy::{Policy, PolicyAxis};
+pub use policy::{EncryptionHint, Policy, PolicyAxis};
 
 #[cfg(test)]
 mod tests;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,20 +3,33 @@ use crate::{error::Error, Attribute, Policy, PolicyAxis};
 fn policy() -> Result<Policy, Error> {
     let sec_level = PolicyAxis::new(
         "Security Level",
-        &["Protected", "Confidential", "Top Secret"],
+        vec![
+            ("Protected", false),
+            ("Confidential", false),
+            ("Top Secret", false),
+        ],
         true,
     );
-    let department = PolicyAxis::new("Department", &["R&D", "HR", "MKG", "FIN"], false);
+    let department = PolicyAxis::new(
+        "Department",
+        vec![
+            ("R&D", false),
+            ("HR", false),
+            ("MKG", false),
+            ("FIN", false),
+        ],
+        false,
+    );
     let mut policy = Policy::new(100);
-    policy.add_axis(&sec_level)?;
-    policy.add_axis(&department)?;
+    policy.add_axis(sec_level.clone())?;
+    policy.add_axis(department.clone())?;
     // check that policy
     let attributes = policy.attributes();
     assert_eq!(sec_level.len() + department.len(), attributes.len());
-    for att in &sec_level.attributes {
+    for (att, _) in &sec_level.attribute_properties {
         assert!(attributes.contains(&Attribute::new("Security Level", att)))
     }
-    for att in &department.attributes {
+    for (att, _) in &department.attribute_properties {
         assert!(attributes.contains(&Attribute::new("Department", att)))
     }
     for attribute in &attributes {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,22 +1,22 @@
-use crate::{error::Error, Attribute, Policy, PolicyAxis};
+use crate::{error::Error, Attribute, EncryptionHint, Policy, PolicyAxis};
 
 fn policy() -> Result<Policy, Error> {
     let sec_level = PolicyAxis::new(
         "Security Level",
         vec![
-            ("Protected", false),
-            ("Confidential", false),
-            ("Top Secret", false),
+            ("Protected", EncryptionHint::Classic),
+            ("Confidential", EncryptionHint::Classic),
+            ("Top Secret", EncryptionHint::Hybridized),
         ],
         true,
     );
     let department = PolicyAxis::new(
         "Department",
         vec![
-            ("R&D", false),
-            ("HR", false),
-            ("MKG", false),
-            ("FIN", false),
+            ("R&D", EncryptionHint::Classic),
+            ("HR", EncryptionHint::Classic),
+            ("MKG", EncryptionHint::Classic),
+            ("FIN", EncryptionHint::Classic),
         ],
         false,
     );


### PR DESCRIPTION
Hybridization hints are used by the caller to determine which king of encryption to use (hybridized of classic) to encrypt data for a given attribute. This feature brings no functional change.

BREAKING CHANGE:
    - many function signature changes
    - add one `AccessPolicy`  and one `Policy` APIs
    - remove one `Policy` API
